### PR TITLE
fix: fixed dev flag being only true when NODE_ENV is development

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@
 const { spawnSync } = require("child_process");
 const { loadEnvConfig } = require("@next/env");
 
-loadEnvConfig(process.cwd(), process.env.NODE_ENV !== "production");
+loadEnvConfig(process.cwd(), process.env.NODE_ENV === "development");
 
 const args = process.argv.slice(2);
 


### PR DESCRIPTION
## Notes

The change introduced here https://github.com/skirsten/next-env-cli/pull/1/files#diff-180b3d2af89416b99563fff8c37eb8ca1ef7591fc1ddd736b5dacf740ccd3760L6 ensures the flag `dev` is only `true` when `NODE_ENV` is actually `development` and not in other cases too. It will always be `true` even if no `NODE_ENV` is set, for instance. This makes it more explicit what happens, in my opinion.

What do you think @skirsten?

----

FTR: here is the implementation of `loadEnvConfig`: https://github.com/vercel/next.js/blob/ebae05eeedde21cced6dfb325a184da74e739e20/packages/next-env/index.ts#L81-L86.